### PR TITLE
[funcmap] add sub[Month] and add[Month] to functions to golang templa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,13 @@ Pattern uses the glob implementation of [bmatcuk/doublestar](https://github.com/
 
 Pattern can also use golang template format with the following functions:
 
-| Function  | Description                                   | Example                       |
-| --------- | --------------------------------------------- | ----------------------------- |
-| now       | Current [time](https://pkg.go.dev/time#Time)  | `{{ now.Locale.Year }}/*.tgz` |
+| Function | Description                                  | Example                       |
+|----------|----------------------------------------------|-------------------------------|
+| now      | Current [time](https://pkg.go.dev/time#Time) | `{{ now.Locale.Year }}/*.tgz` |
+| add      | Add two int together                         | `{{ add 1 1 }}`               |
+| sub      | Subtracts two int together                   | `{{ sub 1 1 }}`               |
+| addMonth | Add int to time.Month                        | `{{ addMonth now.Month 1 }}`  |
+| subMonth | Subtract int from time.Month                 | `{{ subMonth now.Month 1 }}`  |
 
 ### Trees
 

--- a/internal/exporter/collector.go
+++ b/internal/exporter/collector.go
@@ -173,7 +173,11 @@ func (c *filesCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *filesCollector) Collect(ch chan<- prometheus.Metric) {
 	templater := template.New("pattern").Funcs(
 		template.FuncMap{
-			"now": time.Now,
+			"now":      time.Now,
+			"sub":      func(a, b int) int { return a - b },
+			"add":      func(a, b int) int { return a + b },
+			"subMonth": func(a time.Month, b int) int { return int(a) - b },
+			"addMonth": func(a time.Month, b int) int { return int(a) + b },
 		})
 	for _, tree := range c.trees {
 		c.CollectTree(ch, templater, tree)


### PR DESCRIPTION
**current**

FuncMap supports `now` as the only function.

**changes**
Adds the functions 
- add
- sub
- addMonth
- subMonth

to the FuncMap of the golang template language used in filestat.yaml under `exporter.files.patterns`

**reason**
Sometimes i have folders structures that are organized in years, months and days. I am able to write patterns like:

- `/{{ printf "%02d" (subMonth (now.Month) 1) }}/**/*.tar.gz`
- `/{{ sub now.Year 1 }}/**/*.tar.gz`

I want to monitor folders from this month and last month but not further.

This helps save on runtime as i am not interested on checking folders that are from last year for example as they become irrelevant for my Prometheus alerting.

**risks**

- `Low`. This PR does not introduce any breaking changes so wont break current implementations in the field.
